### PR TITLE
LUGG-107 Add Transliteration module

### DIFF
--- a/luggage_contrib.info
+++ b/luggage_contrib.info
@@ -29,6 +29,7 @@ dependencies[] = rules
 dependencies[] = scheduler
 dependencies[] = strongarm
 dependencies[] = token
+dependencies[] = transliteration
 dependencies[] = views
 features[ctools][] = strongarm:strongarm:1
 features[features_api][] = api:2


### PR DESCRIPTION
This module is required in order to make sure that paths generated by Pathauto don't have quotes or non-URL friendly symbols in them.
