### PR TITLE
LUGG-1020 Remove friendly date format from luggage_contrib

### DIFF
--- a/luggage_contrib.install
+++ b/luggage_contrib.install
@@ -9,14 +9,4 @@ function luggage_contrib_enable() {
     ->condition('type', 'module')
     ->condition('name', 'luggage_contrib')
     ->execute();
-
-  // Create 'Friendly' date format
-  db_insert('date_format_type')
-    ->fields(array(
-      'type' => 'friendly',
-      'title' => 'Friendly',
-      'locked' => 0,
-    ))->execute();
-
-  variable_set('date_format_friendly', 'l, F j, Y - g:ia');
 }


### PR DESCRIPTION
Needed for [the luggage_events branch](https://github.com/isubit/luggage_events/tree/LUGG-1020).

To test:
- Pull down a Luggage site. Checkout this branch and [`LUGG-1020`](https://github.com/isubit/luggage_events/tree/LUGG-102) on the luggage_event module. Run `drush updb -y` (you might have to install the `module_filter` module to do this)
- Look at any event on the site. Did the friendly date format get updated?
- Also, create a fresh luggage site using this branch and [`LUGG-1020`](https://github.com/isubit/luggage_events/tree/LUGG-102) on the luggage_event module. Did the friendly date format get created correctly?